### PR TITLE
add_pet decoupling

### DIFF
--- a/lib/dao/pet_profile_dao.dart
+++ b/lib/dao/pet_profile_dao.dart
@@ -1,63 +1,75 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:sqflite/sqflite.dart';
 
 import 'package:cheart/models/pet_profile_model.dart';
-import 'package:cheart/database/database_helper.dart';
+import 'package:cheart/exceptions/data_access_exception.dart';
 
 class PetProfileDAO {
-  final DatabaseHelper _dbHelper = DatabaseHelper();
+  final Database _db;
+  PetProfileDAO(this._db);
 
-  Future<int> insertPetProfile(PetProfileModel pet) async {
+  static const String _table = 'pet_profiles';
+
+  Future<int> savePetProfile(PetProfileModel pet) async {
     try {
-      final Database db = await _dbHelper.database;
-      return await db.insert(
-        'pet_profiles',
+      return await _db.insert(
+        _table,
         pet.toMap(),
         conflictAlgorithm: ConflictAlgorithm.replace,
       );
+    } on DatabaseException catch (e) {
+      debugPrint('🛑 DatabaseException in insertPetProfile: $e');
+      throw DataAccessException('Failed to insert pet profile', e);
     } catch (e) {
-      print("Error inserting pet profile: $e");
-      rethrow;
+      debugPrint('🛑 Unexpected in insertPetProfile: $e');
+      throw DataAccessException('Unexpected error inserting pet profile', e);
     }
   }
 
   Future<List<PetProfileModel>> getPetProfiles() async {
     try {
-      final Database db = await _dbHelper.database;
-      final List<Map<String, dynamic>> maps = await db.query('pet_profiles');
-      return maps.map((map) => PetProfileModel.fromMap(map)).toList();
-    } catch (e) { // toDo: Update after imp
-      print("Error getting pet profiles: $e");
-      rethrow;
+      final maps = await _db.query(_table);
+      return maps.map((m) => PetProfileModel.fromMap(m)).toList();
+    } on DatabaseException catch (e) {
+      debugPrint('🛑 DatabaseException in getPetProfiles: $e');
+      throw DataAccessException('Failed to load pet profiles', e);
+    } catch (e) {
+      debugPrint('🛑 Unexpected in getPetProfiles: $e');
+      throw DataAccessException('Unexpected error loading pet profiles', e);
     }
   }
 
   Future<int> updatePetProfile(PetProfileModel pet) async {
     try {
-      final Database db = await _dbHelper.database;
-      return await db.update(
-        'pet_profiles',
+      return await _db.update(
+        _table,
         pet.toMap(),
         where: 'id = ?',
         whereArgs: [pet.id],
       );
-    } catch (e) { // toDo: Update after imp
-      print("Error updating pet profile: $e");
-      rethrow;
+    } on DatabaseException catch (e) {
+      debugPrint('🛑 DatabaseException in updatePetProfile: $e');
+      throw DataAccessException('Failed to update pet profile', e);
+    } catch (e) {
+      debugPrint('🛑 Unexpected in updatePetProfile: $e');
+      throw DataAccessException('Unexpected error updating pet profile', e);
     }
   }
 
-  Future<int> deletePetProfile(int id) async {
+  Future<int> deletePetProfile(String id) async {
     try {
-      final Database db = await _dbHelper.database;
-      return await db.delete(
-        'pet_profiles',
+      return await _db.delete(
+        _table,
         where: 'id = ?',
         whereArgs: [id],
       );
-    } catch (e) { // toDo: Update after imp
-      print("Error deleting pet profile: $e");
-      rethrow;
+    } on DatabaseException catch (e) {
+      debugPrint('🛑 DatabaseException in deletePetProfile: $e');
+      throw DataAccessException('Failed to delete pet profile', e);
+    } catch (e) {
+      debugPrint('🛑 Unexpected in deletePetProfile: $e');
+      throw DataAccessException('Unexpected error deleting pet profile', e);
     }
   }
-
 }

--- a/lib/dao/respiratory_session_dao.dart
+++ b/lib/dao/respiratory_session_dao.dart
@@ -3,10 +3,10 @@ import 'package:sqflite/sqflite.dart';
 import 'package:cheart/models/respiratory_session_model.dart';
 
 class RespiratorySessionDAO {
-  static const String _table = 'respiratory_sessions';
-
   final Database db;
   RespiratorySessionDAO(this.db);
+
+  static const String _table = 'respiratory_sessions';
 
   Future<int> insertSession(RespiratorySessionModel session) {
     return db.insert(

--- a/lib/exceptions/data_access_exception.dart
+++ b/lib/exceptions/data_access_exception.dart
@@ -1,0 +1,16 @@
+// Thrown when a data access operation fails in the DAO layer.
+class DataAccessException implements Exception {
+  final String message;
+  final Object? originalError;
+
+  DataAccessException(this.message, [this.originalError]);
+
+  @override
+  String toString() {
+    var base = 'DataAccessException: $message';
+    if (originalError != null) {
+      base += ' – $originalError';
+    }
+    return base;
+  }
+}

--- a/lib/models/pet_profile_model.dart
+++ b/lib/models/pet_profile_model.dart
@@ -67,4 +67,27 @@ class PetProfileModel {
       petImageUrl: map['pet_image_url'] as String?,
     );
   }
+  
+  // Returns a copy of this model with the given fields replaced.
+  PetProfileModel copyWith({
+    int? id,
+    String? petName,
+    int? birthMonth,
+    int? birthYear,
+    String? petBreed,
+    String? vetEmail,
+    String? petImageUrl,
+  }) {
+    return PetProfileModel(
+      id: id ?? this.id,
+      petName: petName ?? this.petName,
+      birthMonth: birthMonth ?? this.birthMonth,
+      birthYear: birthYear ?? this.birthYear,
+      petBreed: petBreed ?? this.petBreed,
+      vetEmail: vetEmail ?? this.vetEmail,
+      petImageUrl: petImageUrl ?? this.petImageUrl,
+    );
+  }
+
+  
 }

--- a/lib/providers/pet_profile_provider.dart
+++ b/lib/providers/pet_profile_provider.dart
@@ -1,11 +1,12 @@
+import 'package:cheart/dao/pet_profile_dao.dart';
 import 'package:flutter/material.dart';
 import 'package:cheart/models/pet_profile_model.dart';
 
 class PetProfileProvider extends ChangeNotifier{
+  // toDo: for testing purposes only. remove later
   final List<PetProfileModel> _petProfiles = [
-    // Temporary default profile until one is selected or added
     PetProfileModel(
-      id: 0,  // temporary id for placeholder profile
+      id: 0,
       petName: 'test',
       petBreed: 'Unknown',
       birthMonth: null,
@@ -14,14 +15,27 @@ class PetProfileProvider extends ChangeNotifier{
     ),
   ];
 
-  // Track the currently selected pet profile
+  late PetProfileDAO _dao;
+
   PetProfileModel? _selectedPetProfile;
 
   List<PetProfileModel> get petProfiles => _petProfiles;
-
   PetProfileModel? get selectedPetProfile => _selectedPetProfile;
-
   List<String> get petNames => _petProfiles.map((profile) => profile.petName).toList();
+
+  void setDao(PetProfileDAO dao) {
+    _dao = dao;
+  }
+
+  // Persists via DAO, updates in-memory list, selects and notifies
+  Future<PetProfileModel> savePetProfile(PetProfileModel pet) async {
+    final newId = await _dao.savePetProfile(pet);
+    final saved = pet.copyWith(id: newId);
+    _petProfiles.add(saved);
+    _selectedPetProfile = saved;
+    notifyListeners();
+    return saved;
+  }
 
   void addPetProfile(PetProfileModel petProfile) {
     _petProfiles.add(petProfile);
@@ -29,6 +43,7 @@ class PetProfileProvider extends ChangeNotifier{
     notifyListeners();
   }
 
+  
   void selectPetProfile(PetProfileModel petProfile) {
     _selectedPetProfile = petProfile;
     notifyListeners();

--- a/lib/providers/respiratory_rate_provider.dart
+++ b/lib/providers/respiratory_rate_provider.dart
@@ -7,10 +7,6 @@ import 'package:flutter/material.dart';
 
 class RespiratoryRateProvider extends ChangeNotifier {
   late RespiratorySessionDAO _dao;
-  
-  void setDao(RespiratorySessionDAO dao) {
-    _dao = dao;
-  }
 
   int _breathCount = 0;
   int _timeRemaining = 30;
@@ -28,6 +24,10 @@ class RespiratoryRateProvider extends ChangeNotifier {
   int get timeRemaining => _timeRemaining;
   bool get isTracking => _isTracking;
   int get breathsPerMinute => _breathCount * 2;
+
+  void setDao(RespiratorySessionDAO dao) {
+    _dao = dao;
+  }
 
   void startTracking() {
     _breathCount = 0;

--- a/tests/components/add_pet_form_tests.dart
+++ b/tests/components/add_pet_form_tests.dart
@@ -12,7 +12,77 @@ class MockPetProfileDAO extends Mock implements PetProfileDAO {}
 
 class MockPetProfileProvider extends Mock implements PetProfileProvider {}
 
+// toDo: get this working
+// ==================== Test: Provider Save and Navigation Pop ====================
+// class MockPetProfileProvider extends Mock implements PetProfileProvider {}
+// class MockNavigatorObserver extends Mock implements NavigatorObserver {}
+
+// void main() {
+//   late MockPetProfileProvider mockProvider;
+//   late MockNavigatorObserver mockObserver;
+
+//   setUp(() {
+//     mockProvider = MockPetProfileProvider();
+//     mockObserver = MockNavigatorObserver();
+//   });
+
+//   testWidgets(
+//     'AddPetForm calls provider.savePetProfile and pops with saved pet',
+//     (WidgetTester tester) async {
+//       // Prepare test pet
+//       final testPet = PetProfileModel(
+//         id: 1,
+//         petName: 'Luna',
+//         petBreed: 'Beagle',
+//         birthMonth: 3,
+//         birthYear: 2020,
+//         vetEmail: 'test@example.com',
+//         petImageUrl: '',
+//       );
+
+//       when(mockProvider.savePetProfile(any))
+//           .thenAnswer((_) async => testPet);
+
+//       await tester.pumpWidget(
+//         MaterialApp(
+//           home: ChangeNotifierProvider<PetProfileProvider>.value(
+//             value: mockProvider,
+//             child: Builder(
+//               builder: (context) => AddPetForm(onSave: (_) {}),
+//             ),
+//           ),
+//           navigatorObservers: [mockObserver],
+//         ),
+//       );
+
+//       // Fill in required fields
+//       await tester.enterText(
+//         find.widgetWithText(TextFormField, 'Pet Name*'),
+//         testPet.petName,
+//       );
+//       await tester.enterText(
+//         find.widgetWithText(TextFormField, 'Breed*'),
+//         testPet.petBreed,
+//       );
+
+//       // Tap Save
+//       await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
+//       await tester.pumpAndSettle();
+
+//       // Verify provider called
+//       verify(mockProvider.savePetProfile(argThat(
+//         isA<PetProfileModel>().having((p) => p.petName, 'petName', 'Luna'),
+//       ))).called(1);
+
+//       // Verify navigation pop
+//       verify(mockObserver.didPop(any, any)).called(1);
+//     },
+//   );
+// }
+
+
 void main() {
+  // ==================== Test: Valid submission triggers onSave callback ====================
   testWidgets('AddPetForm valid submission triggers onSave with correct values',
       (WidgetTester tester) async {
     PetProfileModel? savedPet;

--- a/tests/dao/pet_profile_dao_tests.dart
+++ b/tests/dao/pet_profile_dao_tests.dart
@@ -1,29 +1,52 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqflite_common/sqlite_api.dart';
 
 import 'package:cheart/dao/pet_profile_dao.dart';
-import 'package:cheart/database/database_helper.dart';
 import 'package:cheart/models/pet_profile_model.dart';
+import 'package:cheart/exceptions/data_access_exception.dart';
 
 void main() {
+  // Initialize FFI & point to the ffi factory
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  late Database db;
   late PetProfileDAO dao;
 
-  setUpAll(() {
-    // Initialize sqflite for FFI (for desktop and unit test environments)
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
-  });
-
   setUp(() async {
-    // Create fresh DAO and clear database table before each test
-    dao = PetProfileDAO();
-    final db = await DatabaseHelper().database;
-    await db.delete('pet_profiles');
+    // Open a fresh in-memory database for each test
+    db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (db, version) async {
+          await db.execute('''
+            CREATE TABLE pet_profiles(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              pet_name TEXT NOT NULL,
+              birth_month INTEGER,
+              birth_year INTEGER,
+              pet_breed TEXT NOT NULL,
+              vet_email TEXT,
+              pet_image_url TEXT
+            );
+          ''');
+        },
+      ),
+    );
+
+    // Inject it into your DAO
+    dao = PetProfileDAO(db);
   });
 
-  // ==================== Test: Insert and Retrieve ====================
-  test('should insert and retrieve a pet profile', () async {
+  tearDown(() async {
+    await db.close();
+  });
+
+  // ==================== Test: Save and Retrieve ====================
+  test('savePetProfile inserts and getPetProfiles returns it', () async {
     final pet = PetProfileModel(
       petName: 'Buddy',
       petBreed: 'Golden Retriever',
@@ -32,54 +55,64 @@ void main() {
       vetEmail: 'vet@example.com',
     );
 
-    final id = await dao.insertPetProfile(pet);
-    expect(id, isNonZero); // Ensure a valid row ID was returned
+    final id = await dao.savePetProfile(pet);
+    expect(id, isNonZero);
 
     final pets = await dao.getPetProfiles();
-    expect(pets.length, 1);
+    expect(pets, hasLength(1));
     expect(pets.first.petName, 'Buddy');
     expect(pets.first.petBreed, 'Golden Retriever');
   });
 
+  // ==================== Test: Exception on Missing Table ====================
+  test('getPetProfiles throws DataAccessException when table missing', () async {
+    // Drop the table to simulate a broken schema
+    await db.execute('DROP TABLE pet_profiles;');
+    expect(
+      () => dao.getPetProfiles(),
+      throwsA(isA<DataAccessException>()),
+    );
+  });
+
   // ==================== Test: Update Profile ====================
-  test('should update a pet profile', () async {
+  test('updatePetProfile updates an existing record', () async {
     final pet = PetProfileModel(
-      petName: 'Buddy',
-      petBreed: 'Golden Retriever',
-      birthMonth: 5,
-      birthYear: 2018,
+      petName: 'Max',
+      petBreed: 'Labrador',
+      birthMonth: 6,
+      birthYear: 2019,
     );
+    final id = await dao.savePetProfile(pet);
 
-    final id = await dao.insertPetProfile(pet);
-
-    final updatedPet = PetProfileModel(
+    final updated = PetProfileModel(
       id: id,
-      petName: 'Buddy Updated',
-      petBreed: 'Golden Retriever',
-      birthMonth: 5,
-      birthYear: 2018,
+      petName: 'Maximus',
+      petBreed: 'Labrador',
+      birthMonth: 6,
+      birthYear: 2019,
+      vetEmail: null,
+      petImageUrl: null,
     );
 
-    final rows = await dao.updatePetProfile(updatedPet);
-    expect(rows, 1); // Should affect one row
+    final rowsAffected = await dao.updatePetProfile(updated);
+    expect(rowsAffected, 1);
 
     final pets = await dao.getPetProfiles();
-    expect(pets.first.petName, 'Buddy Updated');
+    expect(pets.first.petName, 'Maximus');
   });
 
   // ==================== Test: Delete Profile ====================
-  test('should delete a pet profile', () async {
+  test('deletePetProfile removes the record', () async {
     final pet = PetProfileModel(
       petName: 'DeleteMe',
-      petBreed: 'Test',
+      petBreed: 'TestBreed',
     );
+    final id = await dao.savePetProfile(pet);
 
-    final id = await dao.insertPetProfile(pet);
-
-    final rowsDeleted = await dao.deletePetProfile(id);
-    expect(rowsDeleted, 1); // One row should be deleted
+    final rowsDeleted = await dao.deletePetProfile(id.toString());
+    expect(rowsDeleted, 1);
 
     final pets = await dao.getPetProfiles();
-    expect(pets, isEmpty); // Confirm table is now empty
+    expect(pets, isEmpty);
   });
 }


### PR DESCRIPTION
Decouple data persistence from AddPetForm

Added:
refactor(ui): decouple data persistence from AddPetForm
- Removed direct PetProfileDAO usage from AddPetForm._handleSave
- Delegated all save logic to PetProfileProvider.savePetProfile
- Injected PetProfileDAO into PetProfileProvider via constructor
- Added copyWith to PetProfileModel for immutable ID assignment
- Clean up provider and DAO implementations (clear separation of concerns)
- Update widget tests to mock provider and verify save + navigation pop - WIP
