### PR TITLE
Add petId for tracking sessions

### DIFF
--- a/lib/components/add_pet_form.dart
+++ b/lib/components/add_pet_form.dart
@@ -6,7 +6,6 @@ import 'package:top_snackbar_flutter/custom_snack_bar.dart';
 import 'package:top_snackbar_flutter/top_snack_bar.dart';
 
 import 'package:cheart/controllers/pet_form_controller.dart';
-import 'package:cheart/dao/pet_profile_dao.dart';
 import 'package:cheart/models/pet_profile_model.dart';
 import 'package:cheart/providers/pet_profile_provider.dart';
 import 'package:cheart/utils/date_utils.dart';

--- a/lib/models/respiratory_session_model.dart
+++ b/lib/models/respiratory_session_model.dart
@@ -6,6 +6,7 @@ enum PetState {
 class RespiratorySessionModel {
   int? sessionId;
   final DateTime timeStamp;
+  final int petId;
   final double respiratoryRate;
   final PetState petState; // pet is at rest or sleep at time of monitoring
   final String? notes;
@@ -14,6 +15,7 @@ class RespiratorySessionModel {
   RespiratorySessionModel({
     this.sessionId,
     required this.timeStamp,
+    required this.petId,
     required this.respiratoryRate,
     required this.petState,
     this.notes,
@@ -30,6 +32,7 @@ class RespiratorySessionModel {
   Map<String, dynamic> toMap() {
     return {
       'session_id': sessionId,
+      'pet_id': petId,
       'time_stamp': timeStamp.toIso8601String(),
       'respiratory_rate': respiratoryRate,
       'pet_state': petState.name,
@@ -40,6 +43,7 @@ class RespiratorySessionModel {
   factory RespiratorySessionModel.fromMap(Map<String, dynamic> map) {
     return RespiratorySessionModel(
       sessionId: map['session_id'] as int?,
+      petId: map['pet_id'] as int,
       timeStamp: DateTime.parse(map['time_stamp'] as String),
       respiratoryRate: (map['respiratory_rate'] as num).toDouble(),
       petState: PetState.values.firstWhere(

--- a/lib/providers/respiratory_rate_provider.dart
+++ b/lib/providers/respiratory_rate_provider.dart
@@ -71,16 +71,31 @@ class RespiratoryRateProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> saveSession(PetState petState) async {
-    if (_sessionTimestamp == null || _finalBreathsPerMinute == null) return;
+  Future<bool> saveSession({
+    required int petId,
+    required PetState petState,
+    String? notes,
+  }) async {
+    if (_sessionTimestamp == null || _finalBreathsPerMinute == null) {
+      return false;
+    }
+
     final session = RespiratorySessionModel(
       sessionId: null,
+      petId: petId,
       timeStamp: _sessionTimestamp!,
       respiratoryRate: _finalBreathsPerMinute!.toDouble(),
       petState: petState,
+      notes: notes,
       isBreathingRateNormal: _finalBreathsPerMinute! <= RespiratoryConstants.highBpmThreshold,
     );
-    await _dao.insertSession(session);
+
+    try {
+      await _dao.insertSession(session);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 
   @override

--- a/lib/screens/respiratory_rate_screen.dart
+++ b/lib/screens/respiratory_rate_screen.dart
@@ -1,4 +1,6 @@
+import 'package:cheart/models/respiratory_session_model.dart';
 import 'package:flutter/material.dart';
+
 import 'package:provider/provider.dart';
 
 import 'package:cheart/components/bottom_navbar.dart';
@@ -13,21 +15,24 @@ class RespiratoryRateScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final petName =
-        context.watch<PetProfileProvider>().selectedPetProfile?.petName ??
-            'your pet';
-    final respiratoryProvider = Provider.of<RespiratoryRateProvider>(context);
-    
+    final selectedPet = context.watch<PetProfileProvider>().selectedPetProfile;
+    final respiratoryProvider = context.watch<RespiratoryRateProvider>();
+
     respiratoryProvider.onSessionComplete ??= () {
-      final breathsPerMinute = context.read<RespiratoryRateProvider>().breathsPerMinute;
+      if (selectedPet == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('No pet selected')),
+        );
+        return;
+      }
+
+      final breathsPerMinute = respiratoryProvider.breathsPerMinute;
       showDialog(
         context: context,
         builder: (_) => PostSessionModal(
-          petName: petName,
+          petName: selectedPet.petName,
+          petId: selectedPet.id ?? -1,
           breathsPerMinute: breathsPerMinute,
-          onSave: (status) {
-            // toDo: connect db
-          },
         ),
       );
     };
@@ -54,7 +59,7 @@ class RespiratoryRateScreen extends StatelessWidget {
                       FittedBox(
                         fit: BoxFit.scaleDown,
                         child: Text(
-                          'Tracking $petName',
+                          'Tracking ${selectedPet?.petName ?? 'your pet'}',
                           style: CHeartTheme.titleText.copyWith(color: Colors.black),
                           textAlign: TextAlign.center,
                         ),

--- a/tests/dao/respiratory_session_model_tests.dart
+++ b/tests/dao/respiratory_session_model_tests.dart
@@ -44,6 +44,7 @@ void main() {
     final now = DateTime.now();
     final session = RespiratorySessionModel(
       sessionId: null,
+      petId: 1,
       timeStamp: now,
       respiratoryRate: 22.5,
       petState: PetState.resting,
@@ -58,6 +59,7 @@ void main() {
     expect(sessions.length, 1);
     final fetched = sessions.first;
     expect(fetched.sessionId, equals(id));
+    expect(fetched.petId, equals(1));
     expect(fetched.timeStamp.toIso8601String(), equals(now.toIso8601String()));
     expect(fetched.respiratoryRate, equals(22.5));
     expect(fetched.petState, equals(PetState.resting));
@@ -68,6 +70,7 @@ void main() {
     // Insert two sessions
     final s1 = RespiratorySessionModel(
       sessionId: null,
+      petId: 1,
       timeStamp: DateTime.now(),
       respiratoryRate: 18.0,
       petState: PetState.sleeping,
@@ -76,6 +79,7 @@ void main() {
     );
     final s2 = RespiratorySessionModel(
       sessionId: null,
+      petId: 2,
       timeStamp: DateTime.now().add(const Duration(minutes: 1)),
       respiratoryRate: 45.0,
       petState: PetState.resting,
@@ -101,6 +105,7 @@ void main() {
   test('updateSession modifies existing record', () async {
     final initial = RespiratorySessionModel(
       sessionId: null,
+      petId: 1,
       timeStamp: DateTime.now(),
       respiratoryRate: 20.0,
       petState: PetState.resting,
@@ -111,6 +116,7 @@ void main() {
 
     final updated = RespiratorySessionModel(
       sessionId: id,
+      petId: 2,
       timeStamp: initial.timeStamp,
       respiratoryRate: 30.0,
       petState: PetState.sleeping,
@@ -129,6 +135,7 @@ void main() {
   test('deleteSession removes the record', () async {
     final toDelete = RespiratorySessionModel(
       sessionId: null,
+      petId: 1,
       timeStamp: DateTime.now(),
       respiratoryRate: 25.0,
       petState: PetState.resting,

--- a/tests/models/respiratory_session_model_tests.dart
+++ b/tests/models/respiratory_session_model_tests.dart
@@ -8,6 +8,7 @@ void main() {
     test('toMap and fromMap preserve all fields correctly', () {
       final now = DateTime.now();
       final original = RespiratorySessionModel(
+        petId: 1,
         sessionId: 42,
         timeStamp: now,
         respiratoryRate: 18.5,
@@ -20,6 +21,7 @@ void main() {
       final reconstructed = RespiratorySessionModel.fromMap(map);
 
       expect(reconstructed.sessionId, equals(42));
+      expect(reconstructed.petId, equals(1));
       expect(reconstructed.timeStamp.toIso8601String(), equals(now.toIso8601String()));
       expect(reconstructed.respiratoryRate, equals(18.5));
       expect(reconstructed.petState, equals(PetState.sleeping));
@@ -31,6 +33,7 @@ void main() {
     test('toString returns a descriptive string', () {
       final now = DateTime.parse('2025-04-17T12:00:00.000Z');
       final model = RespiratorySessionModel(
+        petId: 3,
         sessionId: 7,
         timeStamp: now,
         respiratoryRate: 22.0,
@@ -41,6 +44,7 @@ void main() {
       final str = model.toString();
 
       expect(str, contains('RespiratorySessionModel'));
+      expect(str, contains('petId: 3'));
       expect(str, contains('id: 7'));
       expect(str, contains('timeStamp: $now'));
       expect(str, contains('respiratoryRate: 22.0'));
@@ -53,6 +57,7 @@ void main() {
     test('handles null sessionId correctly in toMap/fromMap', () {
       final now = DateTime.now();
       final model = RespiratorySessionModel(
+        petId: 47,
         sessionId: null,
         timeStamp: now,
         respiratoryRate: 30.0,

--- a/tests/providers/respiratory_rate_provider_tests.dart
+++ b/tests/providers/respiratory_rate_provider_tests.dart
@@ -77,7 +77,7 @@ void main() {
       provider.startTracking();
       final state = PetState.sleeping;
 
-      await provider.saveSession(state);
+      await provider.saveSession(petId: 1, petState: state);
 
       // one insertion
       expect(fakeDao.inserted, hasLength(1));


### PR DESCRIPTION
petId wasn't being inserted into db - fixed

Added:
- added handling for petId in respiratory model and provider
- refactor: saveSession method to pass PetProfileModel so the modal doesn't need to reach around
- refactor: Extracted save logic from inline callback into a private `_handleSave()` method
- updated tests for post_session_modal and respiratory_session_dao//model/provider