### PR TITLE
fix: resolve profile card duplication on creation

### DIFF
--- a/lib/screens/respiratory_rate_screen.dart
+++ b/lib/screens/respiratory_rate_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cheart/models/respiratory_session_model.dart';
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';


### PR DESCRIPTION
Removed addProfile() on selected profile to resolve duplicate cards on profile creation - UI related issue

Added:
- Organized home screen
  - Extract logic into separate methods
  - Error handling + Context.mounted checks
  - Switched provider usage from .watch to .of