### PR TITLE
feature/setting-screen: Implement Settings Screen UI and Functionality

### DIFF
--- a/lib/components/add_pet_form.dart
+++ b/lib/components/add_pet_form.dart
@@ -1,11 +1,9 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:top_snackbar_flutter/custom_snack_bar.dart';
 import 'package:top_snackbar_flutter/top_snack_bar.dart';
 
+import 'package:cheart/components/month_year_picker_dialog.dart';
 import 'package:cheart/components/pet_profile_avatar.dart';
 import 'package:cheart/controllers/pet_form_controller.dart';
 import 'package:cheart/exceptions/image_handler_exception.dart';
@@ -14,6 +12,7 @@ import 'package:cheart/providers/pet_profile_provider.dart';
 import 'package:cheart/utils/date_utils.dart';
 import 'package:cheart/utils/image_handler.dart';
 import 'package:cheart/utils/validators.dart';
+
 
 class AddPetForm extends StatefulWidget {
   final Function(PetProfileModel) onSave;
@@ -49,6 +48,7 @@ class _AddPetFormState extends State<AddPetForm> {
     super.dispose();
   }
 
+  // ────────────────────────── UI ────────────────────────── //
   @override
   Widget build(BuildContext context) {
     final maxWidth = MediaQuery.of(context).size.width;
@@ -68,144 +68,17 @@ class _AddPetFormState extends State<AddPetForm> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                widget.initialPet == null ? 'Add New Pet' : 'Edit Pet',
-                style: const TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.close),
-                onPressed: () => Navigator.pop(context),
-              ),
-            ],
-          ),
-
-          // Avatar picker
-          Center(
-            child: InkWell(
-              onTap: _pickAndCropImage,
-              child: PetProfileAvatar(
-                petName: displayName,
-                imagePath: _imagePath,
-                size: 100.0,
-              ),
-            ),
-          ),
+          _buildHeader(),
+          _buildAvatarPicker(displayName),
           const SizedBox(height: 16),
-
-          // Form fields
-          Flexible(
-            child: SingleChildScrollView(
-              child: Form(
-                key: _formKey,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Pet Name Input
-                    TextFormField(
-                      controller: _controller.nameController,
-                      decoration: const InputDecoration(
-                        labelText: 'Pet Name*',
-                        border: OutlineInputBorder(),
-                        prefixIcon: Icon(Icons.pets),
-                      ),
-                      validator: (value) =>
-                          Validators.required(value, 'pet\'s name'),
-                    ),
-                    const SizedBox(height: 16),
-
-                    // Breed Input
-                    TextFormField(
-                      controller: _controller.breedController,
-                      decoration: const InputDecoration(
-                        labelText: 'Breed*',
-                        border: OutlineInputBorder(),
-                        prefixIcon: Icon(Icons.category),
-                      ),
-                      validator: (value) =>
-                          Validators.required(value, 'pet\'s breed'),
-                    ),
-                    const SizedBox(height: 16),
-
-                    // Birth Date Picker
-                    InkWell(
-                      onTap: () => _showMonthYearPicker(context),
-                      child: InputDecorator(
-                        decoration: const InputDecoration(
-                          labelText: 'Birth Date',
-                          border: OutlineInputBorder(),
-                          prefixIcon: Icon(Icons.calendar_today),
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                              _controller.selectedMonth == null ||
-                                      _controller.selectedYear == null
-                                  ? 'Select Date'
-                                  : formatMonthYear(
-                                      _controller.selectedMonth,
-                                      _controller.selectedYear),
-                              style: TextStyle(
-                                color: _controller.selectedMonth == null ||
-                                        _controller.selectedYear == null
-                                    ? Colors.grey.shade600
-                                    : Colors.black,
-                              ),
-                            ),
-                            const Icon(Icons.arrow_drop_down),
-                          ],
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-
-                    // Vet Email Input
-                    TextFormField(
-                      controller: _controller.vetEmailController,
-                      decoration: const InputDecoration(
-                        labelText: 'Vet Email',
-                        border: OutlineInputBorder(),
-                        prefixIcon: Icon(Icons.email),
-                      ),
-                      keyboardType: TextInputType.emailAddress,
-                      validator: Validators.email,
-                    ),
-                    const SizedBox(height: 16),
-                  ],
-                ),
-              ),
-            ),
-          ),
-
-          // Action Buttons
-          Padding(
-            padding: const EdgeInsets.only(top: 16),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('Cancel'),
-                ),
-                const SizedBox(width: 8),
-                ElevatedButton(
-                  onPressed: _handleSave,
-                  child: const Text('Save'),
-                ),
-              ],
-            ),
-          ),
+          _buildFormFields(),
+          _buildActionButtons(),
         ],
       ),
     );
   }
 
+  // ───────────────────────── Handlers ───────────────────────── //
   Future<void> _pickAndCropImage() async {
     try {
       final newPath = await ImageHandler.pickAndCropImage();
@@ -215,9 +88,7 @@ class _AddPetFormState extends State<AddPetForm> {
         await ImageHandler.deleteImage(_originalImagePath!);
       }
 
-      setState(() {
-        _imagePath = newPath;
-      });
+      setState(() => _imagePath = newPath);
     } on ImageHandlerException catch (e) {
       if (!mounted) return;
       showTopSnackBar(
@@ -231,92 +102,163 @@ class _AddPetFormState extends State<AddPetForm> {
     final pet = _controller.validateAndCreate(_formKey);
     if (pet == null) return;
 
-    final petWithImage = pet.copyWith(
-      petProfileImagePath: _imagePath,
-    );
+    final petWithImage = pet.copyWith(petProfileImagePath: _imagePath);
 
     try {
-      final provider =
-          Provider.of<PetProfileProvider>(context, listen: false);
+      final provider = context.read<PetProfileProvider>();
       final savedPet = await provider.savePetProfile(petWithImage);
-
+      widget.onSave(savedPet);
       if (!mounted) return;
       Navigator.pop(context, savedPet);
     } catch (e) {
       if (!mounted) return;
       showTopSnackBar(
         Overlay.of(context)!,
-        CustomSnackBar.error(message: "Failed to save pet profile: $e"),
+        CustomSnackBar.error(message: 'Failed to save pet profile: $e'),
       );
     }
   }
 
-  void _showMonthYearPicker(BuildContext context) {
-    showDialog(
+  Future<void> _showMonthYearPicker() async {
+    final result = await showDialog<(int?, int?)>(
       context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('Select Birth Date'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Month dropdown
-            DropdownButtonFormField<int>(
-              value: _controller.selectedMonth,
-              decoration: const InputDecoration(
-                labelText: 'Month',
-                border: OutlineInputBorder(),
-              ),
-              items: List.generate(12, (idx) {
-                final month = idx + 1;
-                return DropdownMenuItem(
-                  value: month,
-                  child: Text(
-                    DateFormat('MMMM').format(
-                      DateTime(DateTime.now().year, month),
-                    ),
-                  ),
-                );
-              }),
-              onChanged: (value) {
-                setState(() {
-                  _controller.selectedMonth = value;
-                });
-              },
+      builder: (_) => MonthYearPickerDialog(
+        initialMonth: _controller.selectedMonth,
+        initialYear: _controller.selectedYear,
+      ),
+    );
+
+    if (result != null) {
+      final (month, year) = result;
+      setState(() {
+        _controller.selectedMonth = month;
+        _controller.selectedYear = year;
+      });
+    }
+  }
+
+  // ────────────────────── UI Sub-widgets ────────────────────── //
+  Widget _buildHeader() => Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            widget.initialPet == null ? 'Add New Pet' : 'Edit Pet',
+            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.pop(context),
+          ),
+        ],
+      );
+
+  Widget _buildAvatarPicker(String displayName) => Center(
+        child: InkWell(
+          onTap: _pickAndCropImage,
+          child: PetProfileAvatar(
+            petName: displayName,
+            imagePath: _imagePath,
+            size: 100.0,
+          ),
+        ),
+      );
+
+  Widget _buildFormFields() => Flexible(
+        child: SingleChildScrollView(
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildTextField(
+                  controller: _controller.nameController,
+                  label: 'Pet Name*',
+                  icon: Icons.pets,
+                  validator: (v) => Validators.required(v, 'pet\'s name'),
+                ),
+                const SizedBox(height: 16),
+                _buildTextField(
+                  controller: _controller.breedController,
+                  label: 'Breed*',
+                  icon: Icons.category,
+                  validator: (v) => Validators.required(v, 'pet\'s breed'),
+                ),
+                const SizedBox(height: 16),
+                _buildBirthDatePicker(),
+                const SizedBox(height: 16),
+                _buildTextField(
+                  controller: _controller.vetEmailController,
+                  label: 'Vet Email',
+                  icon: Icons.email,
+                  keyboardType: TextInputType.emailAddress,
+                  validator: Validators.email,
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            // Year dropdown
-            DropdownButtonFormField<int>(
-              value: _controller.selectedYear,
-              decoration: const InputDecoration(
-                labelText: 'Year',
-                border: OutlineInputBorder(),
-              ),
-              items: List.generate(30, (idx) {
-                final year = DateTime.now().year - idx;
-                return DropdownMenuItem(
-                  value: year,
-                  child: Text(year.toString()),
-                );
-              }),
-              onChanged: (value) {
-                setState(() {
-                  _controller.selectedYear = value;
-                });
-              },
+          ),
+        ),
+      );
+
+  Widget _buildActionButtons() => Padding(
+        padding: const EdgeInsets.only(top: 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: _handleSave,
+              child: const Text('Save'),
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
+      );
+
+  // Helper for text fields
+  Widget _buildTextField({
+    required TextEditingController controller,
+    required String label,
+    required IconData icon,
+    FormFieldValidator<String>? validator,
+    TextInputType? keyboardType,
+  }) => TextFormField(
+        controller: controller,
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          prefixIcon: Icon(icon),
+        ),
+        validator: validator,
+        keyboardType: keyboardType,
+      );
+
+  Widget _buildBirthDatePicker() => InkWell(
+        onTap: _showMonthYearPicker,
+        child: InputDecorator(
+          decoration: const InputDecoration(
+            labelText: 'Birth Date',
+            border: OutlineInputBorder(),
+            prefixIcon: Icon(Icons.calendar_today),
           ),
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('OK'),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _controller.selectedMonth == null || _controller.selectedYear == null
+                    ? 'Select Date'
+                    : formatMonthYear(_controller.selectedMonth, _controller.selectedYear),
+                style: TextStyle(
+                  color: _controller.selectedMonth == null || _controller.selectedYear == null
+                      ? Colors.grey.shade600
+                      : Colors.black,
+                ),
+              ),
+              const Icon(Icons.arrow_drop_down),
+            ],
           ),
-        ],
-      ),
-    );
-  }
+        ),
+      );
 }

--- a/lib/components/confirm_discard_dialog.dart
+++ b/lib/components/confirm_discard_dialog.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class ConfirmDiscardDialog extends StatelessWidget {
+  final String title;
+  final String message;
+  final String confirmText;
+  final bool isDestructive;
+
+  const ConfirmDiscardDialog({
+    super.key,
+    required this.title,
+    required this.message,
+    this.confirmText = 'Discard',
+    this.isDestructive = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          style: TextButton.styleFrom(
+            foregroundColor: isDestructive ? Colors.red : null,
+          ),
+          child: Text(confirmText),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/danger_zone_section.dart
+++ b/lib/components/danger_zone_section.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:cheart/models/pet_profile_model.dart';
+import 'package:cheart/providers/pet_profile_provider.dart';
+import 'package:cheart/components/confirm_discard_dialog.dart';
+
+class DangerZoneSection extends StatelessWidget {
+  final PetProfileModel pet;
+  final VoidCallback onPetDeleted;
+
+  const DangerZoneSection({
+    Key? key,
+    required this.pet,
+    required this.onPetDeleted,
+  }) : super(key: key);
+
+  Future<void> _confirmAndDelete(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => const ConfirmDiscardDialog(
+        title: 'Delete Pet Profile?',
+        message: 'This action is permanent and cannot be undone.',
+        confirmText: 'Delete',
+        isDestructive: true,
+      ),
+    );
+
+    if (confirmed == true) {
+      try {
+        final provider =
+            Provider.of<PetProfileProvider>(context, listen: false);
+        await provider.deletePetProfile(pet.id!);
+        onPetDeleted();
+      } catch (e) {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to delete pet: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton.icon(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.red,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        ),
+        onPressed: () => _confirmAndDelete(context),
+        icon: const Icon(Icons.delete),
+        label: const Text('Delete Pet Profile'),
+      ),
+    );
+  }
+}

--- a/lib/components/editable_pet_settings_form.dart
+++ b/lib/components/editable_pet_settings_form.dart
@@ -1,0 +1,246 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:top_snackbar_flutter/custom_snack_bar.dart';
+import 'package:top_snackbar_flutter/top_snack_bar.dart';
+
+import 'package:cheart/components/pet_profile_avatar.dart';
+import 'package:cheart/components/month_year_picker_dialog.dart';
+import 'package:cheart/controllers/pet_form_controller.dart';
+import 'package:cheart/exceptions/image_handler_exception.dart';
+import 'package:cheart/models/pet_profile_model.dart';
+import 'package:cheart/providers/pet_profile_provider.dart';
+import 'package:cheart/themes/cheart_theme.dart';
+import 'package:cheart/utils/date_utils.dart';
+import 'package:cheart/utils/image_handler.dart';
+import 'package:cheart/utils/validators.dart';
+
+class EditablePetSettingsForm extends StatefulWidget {
+  final PetProfileModel pet;
+  final VoidCallback onChangeMade;
+  final VoidCallback onSaved;
+
+  const EditablePetSettingsForm({
+    Key? key,
+    required this.pet,
+    required this.onChangeMade,
+    required this.onSaved,
+  }) : super(key: key);
+
+  @override
+  State<EditablePetSettingsForm> createState() => _EditablePetSettingsFormState();
+}
+
+class _EditablePetSettingsFormState extends State<EditablePetSettingsForm> {
+  final _formKey = GlobalKey<FormState>();
+  late final PetFormController _controller;
+  String? _imagePath;
+  String? _originalImagePath;
+  bool _hasChanges = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PetFormController(initialPet: widget.pet);
+    _imagePath = widget.pet.petProfileImagePath;
+    _originalImagePath = _imagePath;
+
+    // Track text changes
+    _controller.nameController.addListener(_onChangeMade);
+    _controller.breedController.addListener(_onChangeMade);
+    _controller.vetEmailController.addListener(_onChangeMade);
+  }
+
+  @override
+  void dispose() {
+    _controller.nameController.removeListener(_onChangeMade);
+    _controller.breedController.removeListener(_onChangeMade);
+    _controller.vetEmailController.removeListener(_onChangeMade);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  // ────────────────────────── UI ────────────────────────── //
+  @override
+  Widget build(BuildContext context) {
+    final displayName = _controller.nameController.text.isNotEmpty
+        ? _controller.nameController.text
+        : widget.pet.petName;
+
+    return Form(
+      key: _formKey,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildAvatarSection(displayName),
+            const SizedBox(height: 16),
+            _buildNameField(),
+            const SizedBox(height: 16),
+            _buildBreedField(),
+            const SizedBox(height: 16),
+            _buildBirthDatePicker(),
+            const SizedBox(height: 16),
+            _buildVetEmailField(),
+            const SizedBox(height: 24),
+            _buildSaveButton(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ───────────────────────── Handlers ───────────────────────── //
+  void _onChangeMade() {
+    if (!_hasChanges) {
+      _hasChanges = true;
+      widget.onChangeMade();
+    }
+  }
+
+  Future<void> _pickAndCropImage() async {
+    try {
+      final newPath = await ImageHandler.pickAndCropImage();
+      if (!mounted || newPath == null) return;
+
+      if (_originalImagePath != null && _originalImagePath != newPath) {
+        await ImageHandler.deleteImage(_originalImagePath!);
+      }
+
+      setState(() {
+        _imagePath = newPath;
+        _onChangeMade();
+      });
+    } on ImageHandlerException catch (e) {
+      if (!mounted) return;
+      showTopSnackBar(
+        Overlay.of(context)!,
+        CustomSnackBar.error(message: e.message),
+      );
+    }
+  }
+
+  Future<void> _showMonthYearPicker() async {
+    final result = await showDialog<Map<String, int>?>(
+      context: context,
+      builder: (_) => const MonthYearPickerDialog(),
+    );
+
+    if (result != null) {
+      setState(() {
+        _controller.selectedMonth = result['month'];
+        _controller.selectedYear = result['year'];
+        _onChangeMade();
+      });
+    }
+  }
+
+  Future<void> _handleSave() async {
+    final updated = _controller.validateAndCreate(_formKey);
+    if (updated == null) return;
+
+    final petWithImage = updated.copyWith(
+      id: widget.pet.id,
+      petProfileImagePath: _imagePath,
+    );
+
+    try {
+      final provider = context.read<PetProfileProvider>();
+      await provider.updatePetProfile(petWithImage);
+      widget.onSaved();
+      if (!mounted) return;
+      showTopSnackBar(
+        Overlay.of(context)!,
+        const CustomSnackBar.success(message: 'Pet profile updated'),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showTopSnackBar(
+        Overlay.of(context)!,
+        CustomSnackBar.error(message: 'Failed to update pet: $e'),
+      );
+    }
+  }
+
+  // ────────────────────── UI Sub‑widgets ────────────────────── //
+  Widget _buildAvatarSection(String displayName) => Center(
+        child: InkWell(
+          onTap: _pickAndCropImage,
+          child: PetProfileAvatar(
+            petName: displayName,
+            imagePath: _imagePath,
+            isEditable: true,
+            size: 100,
+          ),
+        ),
+      );
+
+  Widget _buildNameField() => TextFormField(
+        controller: _controller.nameController,
+        decoration: const InputDecoration(
+          labelText: 'Pet Name*',
+          border: OutlineInputBorder(),
+          prefixIcon: Icon(Icons.pets),
+        ),
+        validator: (v) => Validators.required(v, 'pet\'s name'),
+      );
+
+  Widget _buildBreedField() => TextFormField(
+        controller: _controller.breedController,
+        decoration: const InputDecoration(
+          labelText: 'Breed*',
+          border: OutlineInputBorder(),
+          prefixIcon: Icon(Icons.category),
+        ),
+        validator: (v) => Validators.required(v, 'pet\'s breed'),
+      );
+
+  Widget _buildBirthDatePicker() => InkWell(
+        onTap: _showMonthYearPicker,
+        child: InputDecorator(
+          decoration: const InputDecoration(
+            labelText: 'Birth Date',
+            border: OutlineInputBorder(),
+            prefixIcon: Icon(Icons.calendar_today),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _controller.selectedMonth == null || _controller.selectedYear == null
+                    ? 'Select Date'
+                    : formatMonthYear(_controller.selectedMonth, _controller.selectedYear),
+                style: TextStyle(
+                  color: _controller.selectedMonth == null || _controller.selectedYear == null
+                      ? Colors.grey.shade600
+                      : Colors.black,
+                ),
+              ),
+              const Icon(Icons.arrow_drop_down),
+            ],
+          ),
+        ),
+      );
+
+  Widget _buildVetEmailField() => TextFormField(
+        controller: _controller.vetEmailController,
+        decoration: const InputDecoration(
+          labelText: 'Vet Email',
+          border: OutlineInputBorder(),
+          prefixIcon: Icon(Icons.email),
+        ),
+        keyboardType: TextInputType.emailAddress,
+        validator: Validators.email,
+      );
+
+  Widget _buildSaveButton() => ElevatedButton(
+        onPressed: _hasChanges ? _handleSave : null,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: CHeartTheme.primaryColor,
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+        ),
+        child: const Text('Save Changes'),
+      );
+}

--- a/lib/components/month_year_picker_dialog.dart
+++ b/lib/components/month_year_picker_dialog.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class MonthYearPickerDialog extends StatefulWidget {
+  final int? initialMonth;
+  final int? initialYear;
+
+  const MonthYearPickerDialog({
+    Key? key,
+    this.initialMonth,
+    this.initialYear,
+  }) : super(key: key);
+
+  @override
+  State<MonthYearPickerDialog> createState() => _MonthYearPickerDialogState();
+}
+
+class _MonthYearPickerDialogState extends State<MonthYearPickerDialog> {
+  int? _selectedMonth;
+  int? _selectedYear;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedMonth = widget.initialMonth;
+    _selectedYear = widget.initialYear;
+  }
+
+  // ────────────────────────── UI ────────────────────────── //
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Select Birth Date'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildMonthDropdown(),
+          const SizedBox(height: 16),
+          _buildYearDropdown(),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, (_selectedMonth, _selectedYear)),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+
+  // ────────────────────── Sub‑widgets ────────────────────── //
+  Widget _buildMonthDropdown() => DropdownButtonFormField<int>(
+        value: _selectedMonth,
+        decoration: const InputDecoration(
+          labelText: 'Month',
+          border: OutlineInputBorder(),
+        ),
+        items: List.generate(12, (i) {
+          final month = i + 1;
+          return DropdownMenuItem(
+            value: month,
+            child: Text(DateFormat('MMMM').format(DateTime(0, month))),
+          );
+        }),
+        onChanged: (val) => setState(() => _selectedMonth = val),
+      );
+
+  Widget _buildYearDropdown() => DropdownButtonFormField<int>(
+        value: _selectedYear,
+        decoration: const InputDecoration(
+          labelText: 'Year',
+          border: OutlineInputBorder(),
+        ),
+        items: List.generate(30, (i) {
+          final year = DateTime.now().year - i;
+          return DropdownMenuItem(value: year, child: Text('$year'));
+        }),
+        onChanged: (val) => setState(() => _selectedYear = val),
+      );
+}

--- a/lib/components/pet_profile_avatar.dart
+++ b/lib/components/pet_profile_avatar.dart
@@ -12,6 +12,10 @@ class PetProfileAvatar extends StatelessWidget {
   final Color? backgroundColor;
   final TextStyle? textStyle;
 
+  // allows editing and responds to tap
+  final bool isEditable;
+  final VoidCallback? onTap;
+
   const PetProfileAvatar({
     Key? key,
     required this.petName,
@@ -19,6 +23,8 @@ class PetProfileAvatar extends StatelessWidget {
     this.size = 80.0,
     this.backgroundColor,
     this.textStyle,
+    this.isEditable = false,
+    this.onTap,
   }) : super(key: key);
 
   // Extract up to two initials from the pet's name
@@ -73,21 +79,48 @@ class PetProfileAvatar extends StatelessWidget {
         ? 'Profile image for $petName'
         : 'No profile image${petName.trim().isNotEmpty ? ', initials ${_getInitials()}' : ''}';
 
+    final avatar = ClipOval(
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: imagePath != null
+            ? Image.file(
+                File(imagePath!),
+                fit: BoxFit.cover,
+                // If loading fails, show initials fallback
+                errorBuilder: (context, error, stackTrace) =>
+                    _buildFallback(context),
+              )
+            : _buildFallback(context),
+      ),
+    );
+
     return Semantics(
       label: semanticsLabel,
-      child: ClipOval(
-        child: SizedBox(
-          width: size,
-          height: size,
-          child: imagePath != null
-              ? Image.file(
-                  File(imagePath!),
-                  fit: BoxFit.cover,
-                  // If loading fails, show initials fallback
-                  errorBuilder: (context, error, stackTrace) =>
-                      _buildFallback(context),
-                )
-              : _buildFallback(context),
+      child: GestureDetector(
+        onTap: isEditable ? onTap : null,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            avatar,
+            if (isEditable)
+              Positioned(
+                bottom: 4,
+                right: 4,
+                child: Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withOpacity(0.6),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.edit,
+                    color: Colors.white,
+                    size: 16,
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );

--- a/tests/components/editable_pet_settings_form_test.dart
+++ b/tests/components/editable_pet_settings_form_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cheart/components/month_year_picker_dialog.dart';
+
+void main() {
+  group('MonthYearPickerDialog', () {
+    testWidgets('tapping OK without changes returns initial values',
+        (WidgetTester tester) async {
+      (int?, int?)? result;
+
+      // Build a button that opens the dialog
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<(int?, int?)>(
+                  context: context,
+                  builder: (_) => const MonthYearPickerDialog(
+                    initialMonth: 4,
+                    initialYear: 2022,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            );
+          }),
+        ),
+      );
+
+      // Open the dialog
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Tap OK
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      // Verify the returned record matches the initial values
+      expect(result, isNotNull);
+      expect(result!.$1, 4);
+      expect(result!.$2, 2022);
+    });
+
+    testWidgets('selecting a different month updates the result',
+        (WidgetTester tester) async {
+      (int?, int?)? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<(int?, int?)>(
+                  context: context,
+                  builder: (_) => const MonthYearPickerDialog(
+                    initialMonth: 1,
+                    initialYear: 2000,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            );
+          }),
+        ),
+      );
+
+      // Open the dialog
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Open the month dropdown (shows 'January')
+      await tester.tap(find.text('January'));
+      await tester.pumpAndSettle();
+
+      // Select 'March'
+      await tester.tap(find.text('March').last);
+      await tester.pumpAndSettle();
+
+      // Tap OK
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      // Verify month changed, year remains initial
+      expect(result, isNotNull);
+      expect(result!.$1, 3);
+      expect(result!.$2, 2000);
+    });
+
+    testWidgets('tapping Cancel returns null', (WidgetTester tester) async {
+      (int?, int?)? result = const (5, 1999);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<(int?, int?)>(
+                  context: context,
+                  builder: (_) => const MonthYearPickerDialog(
+                    initialMonth: 6,
+                    initialYear: 2021,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            );
+          }),
+        ),
+      );
+
+      // Open the dialog
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Tap Cancel
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // Expect result to be null (dialog returns null on cancel)
+      expect(result, isNull);
+    });
+  });
+}

--- a/tests/components/month_year_picker_dialog_test.dart
+++ b/tests/components/month_year_picker_dialog_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cheart/components/month_year_picker_dialog.dart';
+
+void main() {
+  group('MonthYearPickerDialog', () {
+    testWidgets('returns initial values when OK tapped without changes',
+        (WidgetTester tester) async {
+      (int?, int?)? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<(int?, int?)>(
+                  context: context,
+                  builder: (_) => const MonthYearPickerDialog(
+                    initialMonth: 5,
+                    initialYear: 1995,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            );
+          }),
+        ),
+      );
+
+      // Open the dialog
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Verify initial selections are shown
+      expect(find.text('May'), findsOneWidget);
+      expect(find.text('1995'), findsOneWidget);
+
+      // Tap OK
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      // Should return the initial values
+      expect(result, isNotNull);
+      expect(result!.$1, 5);
+      expect(result!.$2, 1995);
+    });
+
+    testWidgets('allows selecting a different month and year',
+        (WidgetTester tester) async {
+      (int?, int?)? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<(int?, int?)>(
+                  context: context,
+                  builder: (_) => const MonthYearPickerDialog(
+                    initialMonth: 1,
+                    initialYear: 2000,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            );
+          }),
+        ),
+      );
+
+      // Open the dialog
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Change month from January to December
+      await tester.tap(find.text('January'));        // open month dropdown
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('December').last);  // select December
+      await tester.pumpAndSettle();
+
+      // Change year from 2000 to 1990
+      await tester.tap(find.text('2000'));           // open year dropdown
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('1990').last);      // select 1990
+      await tester.pumpAndSettle();
+
+      // Confirm selections
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      // Should return the new selections
+      expect(result, isNotNull);
+      expect(result!.$1, 12);   // December
+      expect(result!.$2, 1990);
+    });
+
+    testWidgets('returns null when Cancel is tapped',
+        (WidgetTester tester) async {
+      (int?, int?)? result = const (5, 2005);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<(int?, int?)>(
+                  context: context,
+                  builder: (_) => const MonthYearPickerDialog(
+                    initialMonth: 7,
+                    initialYear: 2010,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            );
+          }),
+        ),
+      );
+
+      // Open the dialog
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Tap Cancel
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // Should return null on cancel
+      expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION
**Branch:** `feature/setting-screen`  

### 1. Reusable Month/Year Picker
- New component: `MonthYearPickerDialog`
- Replaces inline dropdowns in **Add Pet** and **Edit Pet** forms

---

### 2. Form Refactoring
- `AddPetForm` & `EditablePetSettingsForm` now invoke the shared picker
- Switched inner scrollables to `SingleChildScrollView` / bounded `ListView` to resolve layout issues

---

### 3. Danger Zone Section
- New `DangerZoneSection` widget for destructive **Delete Pet Profile** action
- Confirmation handled via `ConfirmDiscardDialog`

---

### 4. SettingsScreen Layout
- Outer `ListView` replaced with `Column` + `Expanded` scrollable form + fixed footer button
- Early-return fallback: if no pet is selected, it immediately pops back to Home

---

### 5. Provider Enhancement
- `PetProfileProvider()` constructor now auto-selects the first in-memory pet
- `deletePetProfile` clears selection when the last pet is removed

---

### 6. Testing
- **Unit tests** for provider: CRUD, load logic, auto-select, delete behavior
- **Widget tests** for `MonthYearPickerDialog`: initial values, selection changes, cancel path
