### PR TITLE
feat(home): add scrollable pet overview cards with session stats

### DIFF
--- a/lib/components/pet_profile/pet_card_list.dart
+++ b/lib/components/pet_profile/pet_card_list.dart
@@ -34,11 +34,10 @@ class PetCardList extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           physics: const BouncingScrollPhysics(),
           padding: const EdgeInsets.symmetric(horizontal: 5),
-          itemCount:
-              petNames.isEmpty ? 1 : petNames.length + 1, // +1 for add button
+          itemCount: petNames.isEmpty ? 1 : petNames.length + 1, // +1 for add button
           itemBuilder: (context, index) {
-            // Add button is always the last item
-            if (index == (petNames.isEmpty ? 0 : petNames.length)) {
+            // Add button should always be the first item (index == 0)
+            if (index == 0) {
               return GestureDetector(
                 onTap: () async {
                   await onAddPet();
@@ -80,9 +79,11 @@ class PetCardList extends StatelessWidget {
               );
             }
 
-            // Pet Card
+            // Pet Card: Offset index by 1 for petNames since the first item is the add button
+            final petIndex = index - 1;
+
             return InkWell(
-              onTap: () => onPetSelected(petNames[index]),
+              onTap: () => onPetSelected(petNames[petIndex]),
               child: Container(
                 width: 100,
                 margin: const EdgeInsets.all(10),
@@ -93,7 +94,7 @@ class PetCardList extends StatelessWidget {
                 ),
                 child: Center(
                   child: Text(
-                    petNames[index],
+                    petNames[petIndex],
                     style: const TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,

--- a/lib/components/pet_profile/pet_overview_card.dart
+++ b/lib/components/pet_profile/pet_overview_card.dart
@@ -1,0 +1,97 @@
+import 'package:cheart/themes/cheart_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:cheart/components/pet_profile/pet_profile_avatar.dart';
+import 'package:cheart/models/pet_profile_model.dart';
+
+class PetOverviewCard extends StatelessWidget {
+  final PetProfileModel pet;
+  final int sessionCountToday;
+  final double? mostRecentBpm;
+  final DateTime? mostRecentTimestamp;
+
+  const PetOverviewCard({
+    super.key,
+    required this.pet,
+    required this.sessionCountToday,
+    required this.mostRecentBpm,
+    required this.mostRecentTimestamp,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Format the most recent BPM (to one decimal) or show placeholder
+    final bpmText = (mostRecentBpm != null)
+        ? mostRecentBpm!.toStringAsFixed(1)
+        : '—';
+
+    // Format the timestamp if available
+    final timeText = (mostRecentTimestamp != null)
+        ? DateFormat('h:mm a, MMM d').format(mostRecentTimestamp!)
+        : '—';
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: CHeartTheme.cardBackgroundColor,
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Left column: Avatar + Name
+          Column(
+            children: [
+              PetProfileAvatar(
+                petName: pet.petName,
+                imagePath: pet.petProfileImagePath,
+                size: 60.0, // adjust as needed
+              ),
+              const SizedBox(height: 8),
+              Text(
+                pet.petName,
+                style: const TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16,
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(width: 16),
+
+          // Right column: session stats
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Sessions Today: $sessionCountToday',
+                  style: const TextStyle(fontSize: 16),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Most Recent: $bpmText bpm',
+                  style: const TextStyle(fontSize: 16),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'At: $timeText',
+                  style: const TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/models/pet_overview_data.dart
+++ b/lib/models/pet_overview_data.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class PetOverviewData {
+  final int sessionCountToday;
+  final double? mostRecentBpm;
+  final DateTime? mostRecentTimestamp;
+
+  const PetOverviewData({
+    required this.sessionCountToday,
+    required this.mostRecentBpm,
+    required this.mostRecentTimestamp,
+  });
+
+  PetOverviewData copyWith({
+    int? sessionCountToday,
+    double? mostRecentBpm,
+    DateTime? mostRecentTimestamp,
+  }) {
+    return PetOverviewData(
+      sessionCountToday: sessionCountToday ?? this.sessionCountToday,
+      mostRecentBpm: mostRecentBpm ?? this.mostRecentBpm,
+      mostRecentTimestamp: mostRecentTimestamp ?? this.mostRecentTimestamp,
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,21 +1,48 @@
 import 'package:flutter/material.dart';
-
 import 'package:provider/provider.dart';
 import 'package:top_snackbar_flutter/custom_snack_bar.dart';
 import 'package:top_snackbar_flutter/top_snack_bar.dart';
 
-
 import 'package:cheart/components/dialogs/add_pet_modal.dart';
 import 'package:cheart/components/common/bottom_navbar.dart';
 import 'package:cheart/components/pet_profile/pet_card_list.dart';
+import 'package:cheart/components/pet_profile/pet_overview_card.dart';
 import 'package:cheart/models/pet_profile_model.dart';
 import 'package:cheart/providers/pet_profile_provider.dart';
+import 'package:cheart/providers/respiratory_history_provider.dart';
 import 'package:cheart/screens/pet_landing_screen.dart';
 import 'package:cheart/themes/cheart_theme.dart';
 import 'package:cheart/utils/navigation_helpers.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  bool _overviewInitialized = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (!_overviewInitialized) {
+      _overviewInitialized = true;
+
+      final petProvider = context.read<PetProfileProvider>();
+      final petIds = petProvider.petProfiles
+          .where((p) => p.id != null)
+          .map((p) => p.id!)
+          .toList();
+
+      if (petIds.isNotEmpty) {
+        final histProvider = context.read<RespiratoryHistoryProvider>();
+        histProvider.loadOverviewForPets(petIds);
+      }
+    }
+  }
 
   Future<void> _handleAddPet(BuildContext context) async {
     try {
@@ -26,14 +53,13 @@ class HomeScreen extends StatelessWidget {
         ),
       );
 
-      if (!context.mounted) return;
-      if (newPet == null) return;
+      if (!context.mounted || newPet == null) return;
 
       final petProvider = Provider.of<PetProfileProvider>(context, listen: false);
       petProvider.selectPetProfile(newPet);
 
       if (!context.mounted) return;
-      
+
       showTopSnackBar(
         Overlay.of(context),
         const CustomSnackBar.success(
@@ -48,7 +74,7 @@ class HomeScreen extends StatelessWidget {
       );
     } catch (e) {
       if (!context.mounted) return;
-      
+
       showTopSnackBar(
         Overlay.of(context),
         CustomSnackBar.error(
@@ -63,7 +89,7 @@ class HomeScreen extends StatelessWidget {
     final selectedPet = petProvider.petProfiles.firstWhere(
       (profile) => profile.petName == petName,
     );
-    
+
     petProvider.selectPetProfile(selectedPet);
     navigateWithFade(
       context: context,
@@ -89,8 +115,8 @@ class HomeScreen extends StatelessWidget {
                 style: CHeartTheme.sectionTitle,
               ),
               const SizedBox(height: 16),
+
               // Pet Card List
-              //==========================================
               Consumer<PetProfileProvider>(
                 builder: (context, petProvider, child) {
                   return PetCardList(
@@ -100,6 +126,7 @@ class HomeScreen extends StatelessWidget {
                   );
                 },
               ),
+
               const SizedBox(height: 24),
               const Text(
                 'Respiratory Rate Overview',
@@ -107,20 +134,90 @@ class HomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 8),
 
-              // TODO: Replace with Graph widget
-              //==========================================
+              // Overview Cards Section
               Expanded(
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: Colors.grey.shade200,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: const Center(
-                    child: Text('Coming Soon'),
-                  ),
+                child: Consumer2<PetProfileProvider, RespiratoryHistoryProvider>(
+                  builder: (context, petProvider, histProvider, child) {
+                    final pets = petProvider.petProfiles;
+
+                    // If no pets exist, show a message
+                    if (pets.isEmpty) {
+                      return Center(
+                        child: Text(
+                          'No pets yet. Add one to get started!',
+                          style: TextStyle(fontSize: 16, color: Colors.grey.shade600),
+                        ),
+                      );
+                    }
+
+                    // Otherwise, display a scrollable list of overview cards
+                    return ListView.separated(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      itemCount: pets.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemBuilder: (context, index) {
+                        final pet = pets[index];
+                        final overview = histProvider.overviewMap[pet.id];
+                        final error = histProvider.overviewErrors[pet.id];
+
+                        // Loading placeholder (data not yet present and no error)
+                        if (overview == null && error == null) {
+                          return Container(
+                            height: 100,
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(12),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.grey.shade300,
+                                  blurRadius: 4,
+                                  offset: const Offset(0, 2),
+                                ),
+                              ],
+                            ),
+                            child: const Center(child: CircularProgressIndicator()),
+                          );
+                        }
+
+                        // Error card for this pet
+                        if (error != null) {
+                          return Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Colors.red.shade50,
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(color: Colors.red.shade200),
+                            ),
+                            child: Text(
+                              'Error loading data for ${pet.petName}',
+                              style: TextStyle(color: Colors.red.shade700),
+                            ),
+                          );
+                        }
+
+                        // Once overview data is available, wrap the card in an InkWell
+                        return InkWell(
+                          borderRadius: BorderRadius.circular(12),
+                          onTap: () {
+                            Provider.of<PetProfileProvider>(context, listen: false)
+                                .selectPetProfile(pet);
+                            navigateWithFade(
+                              context: context,
+                              destination: const PetLandingScreen(),
+                            );
+                          },
+                          child: PetOverviewCard(
+                            pet: pet,
+                            sessionCountToday: overview!.sessionCountToday,
+                            mostRecentBpm: overview.mostRecentBpm,
+                            mostRecentTimestamp: overview.mostRecentTimestamp,
+                          ),
+                        );
+                      },
+                    );
+                  },
                 ),
               ),
-              //==========================================
             ],
           ),
         ),

--- a/lib/themes/cheart_theme.dart
+++ b/lib/themes/cheart_theme.dart
@@ -3,16 +3,16 @@ import 'package:flutter/material.dart';
 class CHeartTheme {
   // General Colors
   static const Color primaryColor = Color(0xFF6A5AE0); // Purple
-  static const Color backgroundColor = Colors.white;
+  static const Color backgroundColor = Color(0xFFF5F5F5);
   static const Color cardBackgroundColor = Color(0xFFE3E7FF); // Light blue
   static const Color textColor = Colors.black;
   static const Color accentColor = Color(0xFFB4A7E7); // Light purple
   static const Color lightGrey = Color(0xFFBDBDBD); // Light grey
   static const Color bottomNavBackgroundColor = Color(0xF6EFEAFF); // Light pink
 
-static const Color warningBannerColor = Color(0xFFFFF3CD); // Soft yellow
-static const Color warningTextColor = Color(0xFF856404);   // Dark yellow/brown
-static const Color warningBorderColor = Color(0xFFFFEEBA); // Light yellow
+  static const Color warningBannerColor = Color(0xFFFFF3CD); // Soft yellow
+  static const Color warningTextColor = Color(0xFF856404);   // Dark yellow/brown
+  static const Color warningBorderColor = Color(0xFFFFEEBA); // Light yellow
 
 
   // General Text Styles

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -889,10 +889,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
## Overview  
Introduce a new “Respiratory Rate Overview” section on HomeScreen that shows, for each pet:
- Number of sessions recorded today  
- Most recent session’s BPM and timestamp  

Each card is tappable: it selects the pet and navigates to its landing screen upon tap. Data is fetched once per app launch (and refreshed automatically when a new session is added), then cached in the provider.

---

## Changes

### 1. Data Model  
- **`PetOverviewData`** (`lib/models/pet_overview_data.dart`)  
  • Immutable holder of `sessionCountToday`, `mostRecentBpm`, and `mostRecentTimestamp`.

### 2. DAO  
- **`getSessionCountForToday(int petId)`** (`lib/dao/respiratory_session_dao.dart`)  
  • Executes `SELECT COUNT(*)` on `respiratory_sessions` where `time_stamp` falls within today (00:00–23:59).  
  • Wrapped in `_wrap(...)` to surface any `DataAccessException`.

### 3. Provider (`RespiratoryHistoryProvider`)  
- **New fields:**  
  • `overviewMap: Map<int, PetOverviewData>`  
  • `overviewErrors: Map<int, String>`  
- **New method:**  
  ```dart
  Future<void> loadOverviewForPets(List<int> petIds)
